### PR TITLE
Add dataset management

### DIFF
--- a/run_experiment.sh
+++ b/run_experiment.sh
@@ -1,5 +1,5 @@
 python3 CAAC.py \
-    --path './datas' \
+    --datasets datas Kodak hdr \
     --output './logs' \
     --prediction_methods EDP GAP MED DIFF \
     --context_settings BASE \
@@ -7,4 +7,4 @@ python3 CAAC.py \
     # --visualization 
 
 
-    
+   

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,6 +3,18 @@ from .utils import (
     enc,
     dcd,
     calculate_entropy,
+    find_files,
     find_bmp_files,
     visualize_prob_tables,
 )
+
+__all__ = [
+    "dc",
+    "enc",
+    "dcd",
+    "calculate_entropy",
+    "find_files",
+    "find_bmp_files",
+    "visualize_prob_tables",
+]
+

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -150,13 +150,19 @@ def calculate_entropy(arr: np.ndarray) -> float:
 
     return entropy(probs, base=2)
 
-def find_bmp_files(folder_path):
-    bmp_files = []
+def find_files(folder_path: str, extensions=(".bmp",)):
+    """Recursively collect files with given extensions."""
+    file_list = []
+    exts = tuple(e.lower() for e in extensions)
     for root, _, files in os.walk(folder_path):
         for file in files:
-            if file.lower().endswith('.bmp'):
-                bmp_files.append(os.path.join(root, file))
-    return bmp_files
+            if file.lower().endswith(exts):
+                file_list.append(os.path.join(root, file))
+    return sorted(file_list)
+
+# Backward compatibility
+def find_bmp_files(folder_path: str):
+    return find_files(folder_path, (".bmp",))
 
 def visualize_prob_tables(p: np.ndarray,
                           p_gt: np.ndarray,


### PR DESCRIPTION
## Summary
- support multiple datasets via `--datasets`
- add helper `find_files` utility
- update CLI example script
- export new helpers

## Testing
- `python -m py_compile CAAC.py dataset.py utils/utils.py prediction_methods/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6842b3b89af08330825d8d8b78cd5e37